### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:7.4
 MAINTAINER Julien Poulton <julien@codingame.com>
-RUN "npm install mocha"
+RUN ["npm", "install", "mocha", "-g"]
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:7.4
 MAINTAINER Julien Poulton <julien@codingame.com>
 RUN "npm install mocha"
-COPY parse_results.js /
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 cd /project/target
 cp /project/answer/* .
 
-node_modules/mocha/bin/mocha $@ --reporter list
+mocha $@ --reporter list


### PR DESCRIPTION
The `parse_result.js` does not exist anymore, its copy should be removed from the `Dockerfile`. The `RUN` syntax is not exactly the one used.
I propose to install the mocha utility globally to avoid mocha access path problem