### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module.exports = toUpper;
 In order to test the answer, the following unit test is created (file `tests/test.js`):
 
 ```javascript
-var toUpper = require('./toupper.js');
+var toUpper = require('./uppercase.js');
 var assert = require('assert');
 it('should return HELLO', function() {
 	assert.equal('HELLO', toUpper('hello'));


### PR DESCRIPTION
The example test looks for `toupper.js` but the example answer is named `uppercase.js` 